### PR TITLE
Cors Fix

### DIFF
--- a/backend/Properties/launchSettings.json
+++ b/backend/Properties/launchSettings.json
@@ -24,7 +24,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      "applicationUrl": "https://localhost:5001"
     }
   }
 }

--- a/backend/Startup.cs
+++ b/backend/Startup.cs
@@ -25,12 +25,24 @@ namespace backend
             Configuration = configuration;
         }
 
+        readonly string MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
+
         public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddCors();
+            services.AddCors(options =>
+            {
+                options.AddPolicy(MyAllowSpecificOrigins,
+                builder =>
+                {
+                    builder.WithOrigins("http://localhost:3000")
+                    .AllowAnyHeader()
+                    .AllowAnyMethod()
+                    .AllowCredentials();
+                });
+            });
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
 
             var dbConnection = Configuration
@@ -68,13 +80,7 @@ namespace backend
                 app.UseHsts();
             }
 
-            app.UseCors(builder => builder
-                .AllowAnyOrigin()
-                .AllowAnyMethod()
-                .AllowAnyHeader()
-                .AllowCredentials());
-
-            app.UseHttpsRedirection();
+            app.UseCors(MyAllowSpecificOrigins);
             app.UseAuthentication();
             app.UseMvc();
         }

--- a/frontend/src/components/SignIn/SignIn.js
+++ b/frontend/src/components/SignIn/SignIn.js
@@ -48,7 +48,7 @@ export default function SignIn(props) {
   const postLogin = () => {
     axios({
       method: "post",
-      url: "http://localhost:5000/api/token",
+      url: "https://localhost:5001/api/token",
       data: {
         Email: document.getElementById("email").value,
         Password: document.getElementById("password").value
@@ -57,8 +57,8 @@ export default function SignIn(props) {
       .then(function(response) {
         props.setUserJWT(response.data.token);
       })
-      .catch(function(error) {
-        // TODO: "Bad username / password message"
+      .catch(function(e) {
+        console.log(e);
       });
   };
 


### PR DESCRIPTION
TL;DR: This is a fix for that CORS error that was causing issues. I'm very confident in it. Master now works, before it rejected sign-ins.

This specifies localhost 3000 instead of `AllowAnyOrigin()`.

![image](https://user-images.githubusercontent.com/33632286/69664459-0d02c400-104e-11ea-8d65-c8cfa6d3850a.png)

This was causing all preflights to be rejected since AllowAnyOrigin() was used in combination with AllowCredentials(). This wasn't an issue when we originally configured CORS because we weren't actually utilizing AllowCredentials().

Additionally, this PR removes the `http:5000` port entirely, in favor of only hosting `https:5001`. The redirect from 5000 to 5001 doesn't work in a cross origin context, because preflights don't support redirection.

Personally I think only using `https` then makes our requests much more uniform. There will never be a `http` request written in the front end.